### PR TITLE
Replace rest_client with rest-client gem

### DIFF
--- a/esewa.gemspec
+++ b/esewa.gemspec
@@ -30,5 +30,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.10"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec"
-  spec.add_development_dependency "rest_client"
+  spec.add_development_dependency "rest-client"
 end


### PR DESCRIPTION
**Fix Issue**

**Component Name**
Following files has been updated:
- _esewa.gemspec_

**Summary**
Facing issue with following error while running `bin/setup` as mention in the readme to setup esewa. After going through some solution found that gem `rest_client` does not exists in gem source and there is no explicit source defined for it. Appropriate gem for `rest_client` should be `rest-client`

```
esewa git:(master) bin/setup
Fetching gem metadata from https://rubygems.org/..........
Fetching gem metadata from https://rubygems.org/.
Could not find gem 'rest_client' in any of the gem sources listed in your Gemfile.
```

**Technical Depth**
Gem setup was carried out in following specification:
```
Machine: Mac
Ruby Version: 2.4.2
```

